### PR TITLE
Add CosmWasm module skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,10 @@ members = [
   "x/ibc-rs",
   "x/slashing",
   "x/staking",
-  "x/genutil", 
-  "x/upgrade", 
+  "x/genutil",
+  "x/upgrade",
   "x/mint",
+  "x/wasm",
 
   # new unsorted
 ]

--- a/x/wasm/Cargo.toml
+++ b/x/wasm/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependency on gears with features required for modules and CLI integration
+gears = { path = "../../gears", features = ["cli", "xmods", "governance"] }
+
+# CosmWasm execution engine
+cosmwasm-vm = { version = "1", default-features = false, features = ["iterator", "staking"] }
+cosmwasm-std = { version = "1", default-features = false }
+
+# Utilities
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true, default-features = false }
+serde_json = { workspace = true }
+clap = { workspace = true }
+tracing = { workspace = true }
+axum = { workspace = true }
+tonic = { workspace = true }
+
+[dev-dependencies]
+gears = { path = "../../gears", features = ["cli", "xmods", "governance", "utils", "mocks"] }

--- a/x/wasm/src/abci_handler.rs
+++ b/x/wasm/src/abci_handler.rs
@@ -1,0 +1,55 @@
+//! ABCI handler for the CosmWasm module.
+//!
+//! This component wires the `Keeper` into the Gears application runtime. It
+//! implements `ABCIHandler` so that transactions and queries targeting the wasm
+//! module are properly routed. The handler delegates message processing to the
+//! `Keeper` and manages conversion between protobuf-defined types and the
+//! internal representations expected by `cosmwasm_vm`.
+//!
+//! Key responsibilities:
+//! - Dispatch transaction messages (`MsgStoreCode`, `MsgInstantiate`, ...).
+//! - Forward queries to the keeper while enforcing read-only access.
+//! - Register genesis and block lifecycle hooks if required.
+//!
+//! Constraints & Security:
+//! - Must ensure only valid messages are executed and that gas accounting is
+//!   enforced via the provided `TxContext`.
+//! - Avoid panics; all failures should be propagated as `TxError` or
+//!   `QueryError`.
+//! - Queries must not mutate state.
+//!
+//! Implementation of the message handlers is left for future commits.
+use crate::keeper::Keeper;
+use gears::application::handlers::node::{ABCIHandler, TxError};
+use gears::baseapp::errors::QueryError;
+use gears::baseapp::QueryRequest;
+use gears::context::query::QueryContext;
+use gears::context::tx::TxContext;
+
+/// Placeholder struct implementing `ABCIHandler`.
+pub struct WasmABCIHandler<K> {
+    pub keeper: K,
+}
+
+impl<K> ABCIHandler for WasmABCIHandler<K>
+where
+    K: Keeper,
+{
+    fn handle_tx(
+        &self,
+        _ctx: &mut TxContext,
+        _tx: &gears::types::tx::raw::TxWithRaw,
+    ) -> Result<(), TxError> {
+        // TODO: dispatch messages to keeper
+        Ok(())
+    }
+
+    fn handle_query(
+        &self,
+        _ctx: &QueryContext,
+        _req: &QueryRequest,
+    ) -> Result<Vec<u8>, QueryError> {
+        // TODO: dispatch queries to keeper
+        Ok(Vec::new())
+    }
+}

--- a/x/wasm/src/client/cli/mod.rs
+++ b/x/wasm/src/client/cli/mod.rs
@@ -1,0 +1,7 @@
+//! Command line interface for the wasm module.
+//!
+//! Offers subcommands to upload, instantiate and execute contracts as well as to
+//! query state. These commands will integrate with the `clap` based CLI used by
+//! the rest of Gears.
+pub mod query;
+pub mod tx;

--- a/x/wasm/src/client/cli/query.rs
+++ b/x/wasm/src/client/cli/query.rs
@@ -1,0 +1,5 @@
+//! CLI query subcommands for the wasm module.
+//!
+//! These commands will allow users to inspect contract state, list stored code
+//! and more. Each command will translate user input into the appropriate query
+//! type defined in `types::query`.

--- a/x/wasm/src/client/cli/tx.rs
+++ b/x/wasm/src/client/cli/tx.rs
@@ -1,0 +1,5 @@
+//! CLI transaction subcommands for the wasm module.
+//!
+//! These commands will allow users to broadcast `MsgStoreCode`,
+//! `MsgInstantiateContract` and `MsgExecuteContract` transactions. They will
+//! leverage the common transaction builder helpers from `gears`.

--- a/x/wasm/src/client/grpc.rs
+++ b/x/wasm/src/client/grpc.rs
@@ -1,0 +1,4 @@
+//! gRPC service definitions for the wasm module.
+//!
+//! These services will expose query endpoints and transaction submission helpers
+//! compatible with Cosmos SDK tooling.

--- a/x/wasm/src/client/mod.rs
+++ b/x/wasm/src/client/mod.rs
@@ -1,0 +1,8 @@
+//! Client-facing interfaces for the wasm module.
+//!
+//! This directory defines CLI commands, REST handlers and gRPC services that
+//! expose wasm functionality to external users. The layout mirrors the
+//! structure used by other modules in this repository for consistency.
+pub mod cli;
+pub mod grpc;
+pub mod rest;

--- a/x/wasm/src/client/rest.rs
+++ b/x/wasm/src/client/rest.rs
@@ -1,0 +1,4 @@
+//! REST handlers for the wasm module.
+//!
+//! Provide HTTP endpoints that mirror gRPC functionality for simple integration
+//! with web applications.

--- a/x/wasm/src/engine.rs
+++ b/x/wasm/src/engine.rs
@@ -1,0 +1,64 @@
+//! CosmWasm execution engine and trait definitions.
+//!
+//! This module defines the [`WasmEngine`] trait which abstracts over the
+//! underlying execution backend for smart contracts. The default implementation
+//! uses `cosmwasm_vm` and mirrors the high level API provided by the Go
+//! [`wasmvm`](https://github.com/CosmWasm/wasmvm) `VM` struct. It exposes
+//! operations for storing code, instantiating contracts, executing calls,
+//! migrating, querying and handling IBC events.
+//!
+//! Responsibilities:
+//! - Manage a `cosmwasm_vm::Cache` of compiled WASM binaries.
+//! - Provide functions corresponding to the `wasmvm` API such as `store_code`,
+//!   `instantiate`, `execute`, `query` and the IBC callbacks.
+//! - Bridge the VM's `Backend` trait with concrete storage, API and querier
+//!   implementations defined elsewhere in this crate.
+//!
+//! Constraints & Security:
+//! - All execution must be deterministic and respect the gas limits supplied via
+//!   Gears' gas meter integration. No unsafe code is allowed.
+//! - Persistent caches must be pinned/unpinned carefully to avoid leaking memory
+//!   or compiling untrusted code more than once.
+//! - Inputs should be validated to avoid injection of malformed WASM modules.
+//!
+//! This file only defines the trait and a skeletal struct. Implementation will
+//! follow the design laid out in `COSMWASM_ADR.md` and `COSMWASM_PRD.md`.
+use cosmwasm_vm::VmError;
+
+/// High level interface used by the `Keeper` to execute contracts.
+pub trait WasmEngine {
+    /// Stores new contract code and returns an identifier.
+    fn store_code(&mut self, wasm: &[u8]) -> Result<u64, VmError>;
+
+    /// Instantiates a contract from previously stored code.
+    fn instantiate(&mut self, code_id: u64, msg: &[u8]) -> Result<Vec<u8>, VmError>;
+
+    /// Executes a contract call.
+    fn execute(&mut self, contract_addr: &[u8], msg: &[u8]) -> Result<Vec<u8>, VmError>;
+
+    /// Runs a read-only query against a contract.
+    fn query(&self, contract_addr: &[u8], msg: &[u8]) -> Result<Vec<u8>, VmError>;
+}
+
+/// Placeholder engine using `cosmwasm_vm` directly.
+pub struct CosmwasmEngine {
+    // TODO: cache and backend fields
+}
+
+impl WasmEngine for CosmwasmEngine {
+    fn store_code(&mut self, _wasm: &[u8]) -> Result<u64, VmError> {
+        unimplemented!()
+    }
+
+    fn instantiate(&mut self, _code_id: u64, _msg: &[u8]) -> Result<Vec<u8>, VmError> {
+        unimplemented!()
+    }
+
+    fn execute(&mut self, _contract_addr: &[u8], _msg: &[u8]) -> Result<Vec<u8>, VmError> {
+        unimplemented!()
+    }
+
+    fn query(&self, _contract_addr: &[u8], _msg: &[u8]) -> Result<Vec<u8>, VmError> {
+        unimplemented!()
+    }
+}

--- a/x/wasm/src/error.rs
+++ b/x/wasm/src/error.rs
@@ -1,0 +1,24 @@
+//! Error definitions for the wasm module.
+//!
+//! This module centralises all error types that can be returned by the `Keeper`
+//! or `WasmEngine`. Clear error handling is essential for diagnosing contract
+//! failures and ensuring deterministic behaviour across nodes.
+//!
+//! Errors are modelled using `thiserror` and closely mirror the variants found
+//! in `wasmd` and `cosmwasm_vm`.
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum WasmError {
+    /// Returned when contract code fails validation or compilation.
+    #[error("invalid contract code: {0}")]
+    InvalidCode(String),
+
+    /// Wrapper around `cosmwasm_vm::VmError`.
+    #[error("vm error: {0}")]
+    Vm(#[from] cosmwasm_vm::VmError),
+
+    /// Generic keeper failure.
+    #[error("keeper error: {0}")]
+    Keeper(String),
+}

--- a/x/wasm/src/genesis.rs
+++ b/x/wasm/src/genesis.rs
@@ -1,0 +1,37 @@
+//! Genesis state management for the wasm module.
+//!
+//! Handles initial loading of contract code and metadata from the genesis file
+//! as well as exporting the current state during chain upgrades. The structure
+//! mirrors the approach used by `wasmd` where code and contract info are stored
+//! in dedicated sub-stores keyed by identifiers.
+//!
+//! Responsibilities:
+//! - Define `GenesisState` structures serialisable via `serde`/protobuf.
+//! - Provide `init_genesis` and `export_genesis` functions consumed by the
+//!   application during startup and export.
+//! - Validate any embedded contract code for safety before storing.
+//!
+//! Security considerations:
+//! - Genesis contracts may contain malicious code. Validation should include
+//!   checksums and compilation before execution is allowed.
+//! - Panic-free error handling is required to avoid halting the node on corrupt
+//!   genesis files.
+use serde::{Deserialize, Serialize};
+
+/// Structure representing wasm module genesis data.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GenesisState {
+    /// Placeholder for stored contract code and metadata.
+    pub codes: Vec<Vec<u8>>, // TODO: proper structures
+}
+
+/// Initialise module state from genesis data.
+pub fn init_genesis<S>(_state: &GenesisState, _keeper: &mut S) {
+    // TODO: load codes into keeper
+}
+
+/// Export current module state to genesis format.
+pub fn export_genesis<S>(_keeper: &S) -> GenesisState {
+    // TODO: read codes from keeper
+    GenesisState { codes: Vec::new() }
+}

--- a/x/wasm/src/keeper.rs
+++ b/x/wasm/src/keeper.rs
@@ -1,0 +1,53 @@
+//! Core keeper for the wasm module.
+//!
+//! The `Keeper` owns persistent storage keys for contract code and instances and
+//! exposes high level methods used by the rest of the application. It is
+//! conceptually similar to the keeper defined in `wasmd/x/wasm` but adapted to
+//! work with Gears traits and the `WasmEngine` abstraction.
+//!
+//! Major duties include:
+//! - Persisting uploaded contract code and assigning stable identifiers.
+//! - Instantiating contracts with configured permissions and tracking their
+//!   metadata.
+//! - Executing and querying contracts via an associated `WasmEngine` instance.
+//! - Managing contract admin updates, code migration and pinning.
+//!
+//! Constraints & Security:
+//! - All state mutations must go through the provided context traits to ensure
+//!   atomicity and gas accounting.
+//! - Access control should mirror the Cosmos SDK module, preventing unauthorised
+//!   calls.
+//! - The keeper must be free of `unsafe` code as per repository policy.
+use crate::{engine::WasmEngine, error::WasmError};
+
+/// Trait describing keeper behaviour. Concrete implementations will be provided
+/// once the full storage layout is defined.
+pub trait Keeper {
+    /// Store new WASM code and return an id.
+    fn store_code(&mut self, wasm: &[u8]) -> Result<u64, WasmError>;
+
+    /// Instantiate a contract.
+    fn instantiate(&mut self, code_id: u64, msg: &[u8]) -> Result<Vec<u8>, WasmError>;
+
+    /// Execute a contract call.
+    fn execute(&mut self, addr: &[u8], msg: &[u8]) -> Result<Vec<u8>, WasmError>;
+}
+
+/// Basic keeper implementation parametrised by a `WasmEngine`.
+pub struct WasmKeeper<E> {
+    pub engine: E,
+}
+
+impl<E: WasmEngine> Keeper for WasmKeeper<E> {
+    fn store_code(&mut self, wasm: &[u8]) -> Result<u64, WasmError> {
+        self.engine.store_code(wasm).map_err(Into::into)
+    }
+
+    fn instantiate(&mut self, code_id: u64, msg: &[u8]) -> Result<Vec<u8>, WasmError> {
+        self.engine.instantiate(code_id, msg).map_err(Into::into)
+    }
+
+    fn execute(&mut self, addr: &[u8], msg: &[u8]) -> Result<Vec<u8>, WasmError> {
+        self.engine.execute(addr, msg).map_err(Into::into)
+    }
+}

--- a/x/wasm/src/lib.rs
+++ b/x/wasm/src/lib.rs
@@ -1,0 +1,42 @@
+//! CosmWasm module scaffolding.
+//!
+//! This crate integrates the CosmWasm virtual machine (`cosmwasm_vm`) with the
+//! Gears application framework. It mirrors the design of the Go `x/wasm` module
+//! in [`wasmd`](https://github.com/CosmWasm/wasmd) but leverages Rust directly.
+//!
+//! The crate exposes a public `Keeper` responsible for managing contract code
+//! and instances. Execution is delegated to a pluggable [`WasmEngine`] trait,
+//! whose default implementation wraps `cosmwasm_vm`.
+//!
+//! Files are organised following the common xmodule layout:
+//! - `keeper`: state access and business logic
+//! - `engine`: bindings to `cosmwasm_vm`
+//! - `abci_handler`: ABCI entry points
+//! - `genesis`: genesis loading and export
+//! - `message`: transaction message definitions
+//! - `params`: module parameters
+//! - `types`: query structures and internal shared types
+//! - `client`: CLI/REST/GRPC interfaces
+//! - `error`: error types
+//!
+//! Each file contains a more detailed description of its responsibilities and
+//! security considerations.
+
+mod abci_handler;
+mod client;
+mod engine;
+mod error;
+mod genesis;
+mod keeper;
+mod message;
+mod params;
+mod types;
+
+pub use abci_handler::*;
+pub use engine::*;
+pub use error::*;
+pub use genesis::*;
+pub use keeper::*;
+pub use message::*;
+pub use params::*;
+pub use types::*;

--- a/x/wasm/src/message.rs
+++ b/x/wasm/src/message.rs
@@ -1,0 +1,33 @@
+//! Transaction message definitions for the wasm module.
+//!
+//! Messages correspond to user actions such as uploading code, instantiating and
+//! executing contracts. Structures are shaped to be compatible with
+//! `cosmwasm_std` and will ultimately derive the `Tx` procedural macros defined
+//! elsewhere in this repository.
+//!
+//! This file only declares the Rust structs without implementing the protobuf
+//! conversions or CLI wiring yet.
+use serde::{Deserialize, Serialize};
+
+/// Upload new contract code.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MsgStoreCode {
+    pub sender: String,
+    pub wasm_byte_code: Vec<u8>,
+}
+
+/// Instantiate a contract.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MsgInstantiateContract {
+    pub sender: String,
+    pub code_id: u64,
+    pub msg: Vec<u8>,
+}
+
+/// Execute a contract.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MsgExecuteContract {
+    pub sender: String,
+    pub contract: String,
+    pub msg: Vec<u8>,
+}

--- a/x/wasm/src/params.rs
+++ b/x/wasm/src/params.rs
@@ -1,0 +1,18 @@
+//! Module parameter definitions.
+//!
+//! Parameters control gas costs and permissions for wasm execution. They are
+//! loaded from the application parameter store via the standard `ParamsKeeper`
+//! mechanism. The structure closely follows the schema used by `wasmd` so that
+//! existing genesis files and governance proposals remain compatible.
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WasmParams {
+    /// Maximum allowed size for contract byte code in bytes.
+    pub max_wasm_size: u64,
+}
+
+/// Placeholder trait for accessing module params from a keeper.
+pub trait WasmParamsKeeper {
+    fn params(&self) -> WasmParams;
+}

--- a/x/wasm/src/types/mod.rs
+++ b/x/wasm/src/types/mod.rs
@@ -1,0 +1,7 @@
+//! Common query structures for the wasm module.
+//!
+//! This submodule hosts request and response types used by the RPC layer. The
+//! shapes are inspired by `cosmwasm_std` queries so that existing clients can
+//! easily interact with a chain built on Gears.
+
+pub mod query;

--- a/x/wasm/src/types/query.rs
+++ b/x/wasm/src/types/query.rs
@@ -1,0 +1,17 @@
+//! Query request and response types for the wasm module.
+//!
+//! These structures will be used by gRPC/REST endpoints as well as in-process
+//! queries performed by other modules. They are intentionally small for now and
+//! will be expanded to cover the full set of CosmWasm queries (code info,
+//! contract info, raw state etc.).
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryContractInfoRequest {
+    pub address: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryContractInfoResponse {
+    pub code_id: u64,
+}


### PR DESCRIPTION
## Summary
- create `x/wasm` crate for CosmWasm integration
- describe responsibilities and security considerations of each module
- wire new crate into workspace

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets` *(failed: `hidapi` missing system library)*

------
https://chatgpt.com/codex/tasks/task_e_684e65b7274083218bb4605f534e70bd