### PR TITLE
Implement wasm message types

### DIFF
--- a/COSMWASM_PROGRESS.md
+++ b/COSMWASM_PROGRESS.md
@@ -2,8 +2,8 @@
 
 Below is the recommended order for implementing the files within `x/wasm`. Each item includes a short description of its role and key files it interacts with.
 
-- [ ] **x/wasm/Cargo.toml** – crate manifest defining dependencies for the module. It underpins compilation of all subsequent files.
-- [ ] **x/wasm/src/message.rs** – transaction message structures such as `MsgStoreCode` and `MsgInstantiateContract`. Used by `abci_handler.rs` and CLI transaction commands.
+- [x] **x/wasm/Cargo.toml** – crate manifest defining dependencies for the module. It underpins compilation of all subsequent files.
+- [x] **x/wasm/src/message.rs** – transaction message structures such as `MsgStoreCode` and `MsgInstantiateContract`. Used by `abci_handler.rs` and CLI transaction commands.
 - [ ] **x/wasm/src/types/query.rs** – request and response types for contract queries. Consumed by the ABCI handler and all client interfaces.
 - [ ] **x/wasm/src/types/mod.rs** – exposes the query submodule for external use. Acts as the entry point for `crate::types`.
 - [ ] **x/wasm/src/params.rs** – module parameters controlling wasm behaviour. Accessed from `keeper.rs`.

--- a/x/wasm/src/message.rs
+++ b/x/wasm/src/message.rs
@@ -1,33 +1,52 @@
 //! Transaction message definitions for the wasm module.
 //!
-//! Messages correspond to user actions such as uploading code, instantiating and
-//! executing contracts. Structures are shaped to be compatible with
-//! `cosmwasm_std` and will ultimately derive the `Tx` procedural macros defined
-//! elsewhere in this repository.
-//!
-//! This file only declares the Rust structs without implementing the protobuf
-//! conversions or CLI wiring yet.
+//! Messages correspond to actions such as uploading code, instantiating and
+//! executing contracts. Structures implement the `AppMessage` derive to integrate
+//! with the rest of the application.
+
+use gears::derive::AppMessage;
 use serde::{Deserialize, Serialize};
 
 /// Upload new contract code.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, AppMessage)]
+#[msg(url = "/cosmwasm.wasm.v1.MsgStoreCode")]
 pub struct MsgStoreCode {
+    #[msg(signer)]
     pub sender: String,
     pub wasm_byte_code: Vec<u8>,
 }
 
 /// Instantiate a contract.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, AppMessage)]
+#[msg(url = "/cosmwasm.wasm.v1.MsgInstantiateContract")]
 pub struct MsgInstantiateContract {
+    #[msg(signer)]
     pub sender: String,
     pub code_id: u64,
     pub msg: Vec<u8>,
 }
 
 /// Execute a contract.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, AppMessage)]
+#[msg(url = "/cosmwasm.wasm.v1.MsgExecuteContract")]
 pub struct MsgExecuteContract {
+    #[msg(signer)]
     pub sender: String,
     pub contract: String,
     pub msg: Vec<u8>,
+}
+
+/// Enum grouping all CosmWasm messages.
+#[derive(Debug, Clone, Serialize, AppMessage)]
+#[serde(tag = "@type")]
+pub enum Message {
+    #[serde(rename = "/cosmwasm.wasm.v1.MsgStoreCode")]
+    #[msg(url(path = MsgStoreCode::TYPE_URL))]
+    StoreCode(MsgStoreCode),
+    #[serde(rename = "/cosmwasm.wasm.v1.MsgInstantiateContract")]
+    #[msg(url(path = MsgInstantiateContract::TYPE_URL))]
+    Instantiate(MsgInstantiateContract),
+    #[serde(rename = "/cosmwasm.wasm.v1.MsgExecuteContract")]
+    #[msg(url(path = MsgExecuteContract::TYPE_URL))]
+    Execute(MsgExecuteContract),
 }


### PR DESCRIPTION
## Summary
- add `MsgStoreCode`, `MsgInstantiateContract` and `MsgExecuteContract` with AppMessage derives
- add enum grouping these messages
- mark first two items complete in COSMWASM progress checklist

## Testing
- `cargo fmt --all`
- `cargo clippy -p wasm --all-targets -- -D warnings` *(fails: libudev missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e6c77f828832193d65f1264d29602