### PR TITLE
Implement wasm query types

### DIFF
--- a/COSMWASM_PROGRESS.md
+++ b/COSMWASM_PROGRESS.md
@@ -4,7 +4,7 @@ Below is the recommended order for implementing the files within `x/wasm`. Each 
 
 - [x] **x/wasm/Cargo.toml** – crate manifest defining dependencies for the module. It underpins compilation of all subsequent files.
 - [x] **x/wasm/src/message.rs** – transaction message structures such as `MsgStoreCode` and `MsgInstantiateContract`. Used by `abci_handler.rs` and CLI transaction commands.
-- [ ] **x/wasm/src/types/query.rs** – request and response types for contract queries. Consumed by the ABCI handler and all client interfaces.
+- [x] **x/wasm/src/types/query.rs** – request and response types for contract queries. Consumed by the ABCI handler and all client interfaces.
 - [ ] **x/wasm/src/types/mod.rs** – exposes the query submodule for external use. Acts as the entry point for `crate::types`.
 - [ ] **x/wasm/src/params.rs** – module parameters controlling wasm behaviour. Accessed from `keeper.rs`.
 - [ ] **x/wasm/src/error.rs** – common error enum for the wasm module. Imported by the engine and keeper implementations.

--- a/x/wasm/src/types/query.rs
+++ b/x/wasm/src/types/query.rs
@@ -6,12 +6,77 @@
 //! contract info, raw state etc.).
 use serde::{Deserialize, Serialize};
 
+/// Query the metadata for a given contract address.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueryContractInfoRequest {
+    /// Bech32 address of the contract.
     pub address: String,
 }
 
+/// Response containing the code identifier the contract was instantiated from.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueryContractInfoResponse {
+    /// Identifier of the uploaded WASM code.
     pub code_id: u64,
+}
+
+/// Request the raw bytes of stored code.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryCodeRequest {
+    /// Identifier returned by a previous `MsgStoreCode` call.
+    pub code_id: u64,
+}
+
+/// Response with the original wasm bytecode.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryCodeResponse {
+    pub wasm_byte_code: Vec<u8>,
+}
+
+/// Request all known code identifiers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryCodesRequest {}
+
+/// Response listing stored code identifiers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryCodesResponse {
+    pub code_ids: Vec<u64>,
+}
+
+/// Request contracts that were instantiated from a particular code id.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryContractsByCodeRequest {
+    pub code_id: u64,
+}
+
+/// Response listing contract addresses.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryContractsByCodeResponse {
+    pub contracts: Vec<String>,
+}
+
+/// Request a smart query to be executed by the contract.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QuerySmartContractStateRequest {
+    pub address: String,
+    pub query_data: Vec<u8>,
+}
+
+/// Response with the json bytes returned by the contract.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QuerySmartContractStateResponse {
+    pub data: Vec<u8>,
+}
+
+/// Request a raw key from the contract storage.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryRawContractStateRequest {
+    pub address: String,
+    pub key: Vec<u8>,
+}
+
+/// Response with raw value bytes.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryRawContractStateResponse {
+    pub data: Vec<u8>,
 }


### PR DESCRIPTION
## Summary
- add query request and response structures for the CosmWasm module
- mark `x/wasm/src/types/query.rs` as complete in the progress checklist

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets` *(fails: unable to find system library `libudev`)*

------
https://chatgpt.com/codex/tasks/task_e_684e6f952f4483219a73276867434a4f