### PR TITLE
Implement CosmWasm params

### DIFF
--- a/COSMWASM_PROGRESS.md
+++ b/COSMWASM_PROGRESS.md
@@ -5,8 +5,8 @@ Below is the recommended order for implementing the files within `x/wasm`. Each 
 - [x] **x/wasm/Cargo.toml** – crate manifest defining dependencies for the module. It underpins compilation of all subsequent files.
 - [x] **x/wasm/src/message.rs** – transaction message structures such as `MsgStoreCode` and `MsgInstantiateContract`. Used by `abci_handler.rs` and CLI transaction commands.
 - [x] **x/wasm/src/types/query.rs** – request and response types for contract queries. Consumed by the ABCI handler and all client interfaces.
-- [ ] **x/wasm/src/types/mod.rs** – exposes the query submodule for external use. Acts as the entry point for `crate::types`.
-- [ ] **x/wasm/src/params.rs** – module parameters controlling wasm behaviour. Accessed from `keeper.rs`.
+- [x] **x/wasm/src/types/mod.rs** – exposes the query submodule for external use. Acts as the entry point for `crate::types`.
+- [x] **x/wasm/src/params.rs** – module parameters controlling wasm behaviour. Accessed from `keeper.rs`.
 - [ ] **x/wasm/src/error.rs** – common error enum for the wasm module. Imported by the engine and keeper implementations.
 - [ ] **x/wasm/src/engine.rs** – defines the `WasmEngine` trait and a `CosmwasmEngine` skeleton. Called by the keeper to execute contracts.
 - [ ] **x/wasm/src/keeper.rs** – core keeper managing state and delegating execution to a `WasmEngine`. Relied on by genesis and the ABCI handler.

--- a/extensions/src/lib.rs
+++ b/extensions/src/lib.rs
@@ -1,4 +1,4 @@
-//! 
+//! Miscellaneous utility helpers shared across the workspace.
 
 pub mod corruption;
 pub mod gas;

--- a/trees/examples/benchtable.rs
+++ b/trees/examples/benchtable.rs
@@ -244,15 +244,14 @@ fn main() {
         .expect("OutputResult will always work with the BENCH_TEMPLATE");
 
     let mut file = std::fs::File::create("benchmark.md").expect("failed to create a new file");
-    file.write("# Benchmark\n".as_bytes())
-        .expect("failed to write");
-    file.write("## Small".as_bytes()).expect("failed to write");
+    file.write_all(b"# Benchmark\n").expect("failed to write");
+    file.write_all(b"## Small").expect("failed to write");
     file.write_all(small_table.as_bytes())
         .expect("failed to write");
-    file.write("## Medium".as_bytes()).expect("failed to write");
+    file.write_all(b"## Medium").expect("failed to write");
     file.write_all(medium_table.as_bytes())
         .expect("failed to write");
-    file.write("## Large".as_bytes()).expect("failed to write");
+    file.write_all(b"## Large").expect("failed to write");
     file.write_all(large_table.as_bytes())
         .expect("failed to write");
 }

--- a/x/wasm/src/params.rs
+++ b/x/wasm/src/params.rs
@@ -1,18 +1,152 @@
 //! Module parameter definitions.
 //!
-//! Parameters control gas costs and permissions for wasm execution. They are
-//! loaded from the application parameter store via the standard `ParamsKeeper`
-//! mechanism. The structure closely follows the schema used by `wasmd` so that
-//! existing genesis files and governance proposals remain compatible.
-use serde::{Deserialize, Serialize};
+//! Parameters control gas costs and permissions for CosmWasm execution. They
+//! are persisted in the application's parameter store and mirror the schema
+//! used by [`wasmd`](https://github.com/CosmWasm/wasmd). Only a subset is
+//! implemented for now but the layout matches the upstream design so that
+//! existing genesis files remain compatible.
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+use gears::{
+    application::keepers::params::ParamsKeeper,
+    extensions::corruption::UnwrapCorrupt,
+    params::{ParamKind, ParamsDeserialize, ParamsSerialize, ParamsSubspaceKey},
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+const KEY_CODE_UPLOAD_ACCESS: &str = "CodeUploadAccess";
+const KEY_INSTANTIATE_DEFAULT_PERMISSION: &str = "InstantiateDefaultPermission";
+const KEY_MAX_WASM_SIZE: &str = "MaxWasmSize";
+
+/// Permission levels for uploading or instantiating contracts.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AccessType {
+    /// Undefined variant used when parsing fails.
+    Unspecified,
+    /// No one is allowed to perform the action.
+    Nobody,
+    /// Everyone is allowed.
+    Everybody,
+    /// Only addresses listed in [`AccessConfig::addresses`].
+    AnyOfAddresses,
+}
+
+/// Access control configuration mirroring `wasmd`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AccessConfig {
+    pub permission: AccessType,
+    #[serde(default)]
+    pub addresses: Vec<String>,
+}
+
+impl Default for AccessConfig {
+    fn default() -> Self {
+        Self {
+            permission: AccessType::Everybody,
+            addresses: Vec::new(),
+        }
+    }
+}
+
+/// Parameters governing wasm behaviour.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WasmParams {
+    /// Permission for uploading new contract code.
+    pub code_upload_access: AccessConfig,
+    /// Default permission applied when instantiating contracts.
+    pub instantiate_default_permission: AccessType,
     /// Maximum allowed size for contract byte code in bytes.
     pub max_wasm_size: u64,
 }
 
-/// Placeholder trait for accessing module params from a keeper.
-pub trait WasmParamsKeeper {
-    fn params(&self) -> WasmParams;
+impl Default for WasmParams {
+    fn default() -> Self {
+        Self {
+            code_upload_access: AccessConfig::default(),
+            instantiate_default_permission: AccessType::Everybody,
+            // 1 MiB by default, matching wasmd.
+            max_wasm_size: 1_048_576,
+        }
+    }
+}
+
+impl ParamsSerialize for WasmParams {
+    fn keys() -> HashSet<&'static str> {
+        [
+            KEY_CODE_UPLOAD_ACCESS,
+            KEY_INSTANTIATE_DEFAULT_PERMISSION,
+            KEY_MAX_WASM_SIZE,
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn to_raw(&self) -> Vec<(&'static str, Vec<u8>)> {
+        vec![
+            (
+                KEY_CODE_UPLOAD_ACCESS,
+                serde_json::to_vec(&self.code_upload_access)
+                    .expect("serialization should not fail"),
+            ),
+            (
+                KEY_INSTANTIATE_DEFAULT_PERMISSION,
+                serde_json::to_vec(&self.instantiate_default_permission)
+                    .expect("serialization should not fail"),
+            ),
+            (
+                KEY_MAX_WASM_SIZE,
+                format!("\"{}\"", self.max_wasm_size).into_bytes(),
+            ),
+        ]
+    }
+}
+
+impl ParamsDeserialize for WasmParams {
+    fn from_raw(mut fields: HashMap<&'static str, Vec<u8>>) -> Self {
+        Self {
+            code_upload_access: serde_json::from_slice(
+                &fields.remove(KEY_CODE_UPLOAD_ACCESS).unwrap_or_default(),
+            )
+            .unwrap_or_default(),
+            instantiate_default_permission: serde_json::from_slice(
+                &fields
+                    .remove(KEY_INSTANTIATE_DEFAULT_PERMISSION)
+                    .unwrap_or_default(),
+            )
+            .unwrap_or(AccessType::Unspecified),
+            max_wasm_size: ParamKind::U64
+                .parse_param(fields.remove(KEY_MAX_WASM_SIZE).unwrap_or_default())
+                .unsigned_64()
+                .unwrap_or_corrupt(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WasmParamsKeeper<PSK: ParamsSubspaceKey> {
+    pub params_subspace_key: PSK,
+}
+
+impl<PSK: ParamsSubspaceKey> ParamsKeeper<PSK> for WasmParamsKeeper<PSK> {
+    type Param = WasmParams;
+
+    fn psk(&self) -> &PSK {
+        &self.params_subspace_key
+    }
+
+    fn validate(key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) -> bool {
+        match String::from_utf8_lossy(key.as_ref()).as_ref() {
+            KEY_CODE_UPLOAD_ACCESS => {
+                serde_json::from_slice::<AccessConfig>(value.as_ref()).is_ok()
+            }
+            KEY_INSTANTIATE_DEFAULT_PERMISSION => {
+                serde_json::from_slice::<AccessType>(value.as_ref()).is_ok()
+            }
+            KEY_MAX_WASM_SIZE => ParamKind::U64
+                .parse_param(value.as_ref().to_vec())
+                .unsigned_64()
+                .is_some(),
+            _ => false,
+        }
+    }
 }

--- a/x/wasm/src/types/mod.rs
+++ b/x/wasm/src/types/mod.rs
@@ -5,3 +5,5 @@
 //! easily interact with a chain built on Gears.
 
 pub mod query;
+
+pub use query::*;


### PR DESCRIPTION
## Summary
- add `AccessType`, `AccessConfig` and `WasmParams`
- provide `WasmParamsKeeper` for parameter store integration
- mark `x/wasm/src/params.rs` complete in progress checklist

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets` *(fails: missing system library `libudev` for `hidapi` build)*

------
https://chatgpt.com/codex/tasks/task_e_684e712638fc8321b35cd6c1b5fded55