### PR TITLE
Implement wasm REST handlers

### DIFF
--- a/COSMWASM_PROGRESS.md
+++ b/COSMWASM_PROGRESS.md
@@ -16,6 +16,6 @@ Below is the recommended order for implementing the files within `x/wasm`. Each 
 - [x] **x/wasm/src/client/cli/tx.rs** – CLI subcommands for broadcasting wasm transactions defined in `message.rs`.
 - [x] **x/wasm/src/client/cli/mod.rs** – groups the query and transaction CLI into a single module.
 - [x] **x/wasm/src/client/grpc.rs** – gRPC service definitions exposing query and transaction helpers for external tooling.
-- [ ] **x/wasm/src/client/rest.rs** – REST handlers mirroring the gRPC interface for web applications.
+- [x] **x/wasm/src/client/rest.rs** – REST handlers mirroring the gRPC interface for web applications.
 - [ ] **x/wasm/src/client/mod.rs** – aggregates CLI, gRPC and REST interfaces for consumers.
 - [ ] **x/wasm/src/lib.rs** – module root re-exporting the keeper, engine, clients and other components; depends on all previous files.

--- a/x/wasm/src/client/rest.rs
+++ b/x/wasm/src/client/rest.rs
@@ -2,3 +2,141 @@
 //!
 //! Provide HTTP endpoints that mirror gRPC functionality for simple integration
 //! with web applications.
+
+use crate::{
+    types::query::{
+        QueryCodeRequest, QueryCodesRequest, QueryContractInfoRequest, QueryContractsByCodeRequest,
+        QueryRawContractStateRequest, QuerySmartContractStateRequest,
+    },
+    WasmNodeQueryRequest, WasmNodeQueryResponse,
+};
+use axum::{
+    extract::{Path, State},
+    routing::get,
+    Json, Router,
+};
+use gears::{
+    baseapp::{NodeQueryHandler, QueryRequest, QueryResponse},
+    rest::{error::HTTPError, RestState},
+};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct SmartQuery {
+    /// Hex or plain string encoded JSON query.
+    query_data: String,
+}
+
+#[derive(Deserialize)]
+struct RawQuery {
+    /// Hex or plain string encoded key bytes.
+    query_data: String,
+}
+
+/// Get contract metadata by address.
+pub async fn contract_info<
+    QReq: QueryRequest + From<WasmNodeQueryRequest>,
+    QRes: QueryResponse + TryInto<WasmNodeQueryResponse>,
+    App: NodeQueryHandler<QReq, QRes>,
+>(
+    Path(address): Path<String>,
+    State(rest_state): State<RestState<QReq, QRes, App>>,
+) -> Result<Json<QRes>, HTTPError> {
+    let req = WasmNodeQueryRequest::ContractInfo(QueryContractInfoRequest { address });
+    let res = rest_state.app.typed_query(req)?;
+    Ok(Json(res))
+}
+
+/// Download raw wasm code by id.
+pub async fn code<
+    QReq: QueryRequest + From<WasmNodeQueryRequest>,
+    QRes: QueryResponse + TryInto<WasmNodeQueryResponse>,
+    App: NodeQueryHandler<QReq, QRes>,
+>(
+    Path(code_id): Path<u64>,
+    State(rest_state): State<RestState<QReq, QRes, App>>,
+) -> Result<Json<QRes>, HTTPError> {
+    let req = WasmNodeQueryRequest::Code(QueryCodeRequest { code_id });
+    let res = rest_state.app.typed_query(req)?;
+    Ok(Json(res))
+}
+
+/// List metadata for all stored wasm codes.
+pub async fn codes<
+    QReq: QueryRequest + From<WasmNodeQueryRequest>,
+    QRes: QueryResponse + TryInto<WasmNodeQueryResponse>,
+    App: NodeQueryHandler<QReq, QRes>,
+>(
+    State(rest_state): State<RestState<QReq, QRes, App>>,
+) -> Result<Json<QRes>, HTTPError> {
+    let req = WasmNodeQueryRequest::Codes(QueryCodesRequest {});
+    let res = rest_state.app.typed_query(req)?;
+    Ok(Json(res))
+}
+
+/// List contracts instantiated from a given code id.
+pub async fn contracts_by_code<
+    QReq: QueryRequest + From<WasmNodeQueryRequest>,
+    QRes: QueryResponse + TryInto<WasmNodeQueryResponse>,
+    App: NodeQueryHandler<QReq, QRes>,
+>(
+    Path(code_id): Path<u64>,
+    State(rest_state): State<RestState<QReq, QRes, App>>,
+) -> Result<Json<QRes>, HTTPError> {
+    let req = WasmNodeQueryRequest::ContractsByCode(QueryContractsByCodeRequest { code_id });
+    let res = rest_state.app.typed_query(req)?;
+    Ok(Json(res))
+}
+
+/// Execute a smart query against a contract.
+pub async fn smart_contract_state<
+    QReq: QueryRequest + From<WasmNodeQueryRequest>,
+    QRes: QueryResponse + TryInto<WasmNodeQueryResponse>,
+    App: NodeQueryHandler<QReq, QRes>,
+>(
+    Path((address, SmartQuery { query_data })): Path<(String, SmartQuery)>,
+    State(rest_state): State<RestState<QReq, QRes, App>>,
+) -> Result<Json<QRes>, HTTPError> {
+    let data = hex::decode(&query_data).unwrap_or_else(|_| query_data.into_bytes());
+    let req = WasmNodeQueryRequest::Smart(QuerySmartContractStateRequest {
+        address,
+        query_data: data,
+    });
+    let res = rest_state.app.typed_query(req)?;
+    Ok(Json(res))
+}
+
+/// Read a raw key from a contract's storage.
+pub async fn raw_contract_state<
+    QReq: QueryRequest + From<WasmNodeQueryRequest>,
+    QRes: QueryResponse + TryInto<WasmNodeQueryResponse>,
+    App: NodeQueryHandler<QReq, QRes>,
+>(
+    Path((address, RawQuery { query_data })): Path<(String, RawQuery)>,
+    State(rest_state): State<RestState<QReq, QRes, App>>,
+) -> Result<Json<QRes>, HTTPError> {
+    let key = hex::decode(&query_data).unwrap_or_else(|_| query_data.into_bytes());
+    let req = WasmNodeQueryRequest::Raw(QueryRawContractStateRequest { address, key });
+    let res = rest_state.app.typed_query(req)?;
+    Ok(Json(res))
+}
+
+pub fn get_router<
+    QReq: QueryRequest + From<WasmNodeQueryRequest>,
+    QRes: QueryResponse + TryInto<WasmNodeQueryResponse>,
+    App: NodeQueryHandler<QReq, QRes>,
+>() -> Router<RestState<QReq, QRes, App>> {
+    Router::new()
+        .route("/v1/contract/:address", get(contract_info))
+        .route("/v1/code/:code_id", get(code))
+        .route("/v1/code", get(codes))
+        .route("/v1/code/:code_id/contracts", get(contracts_by_code))
+        .route(
+            "/v1/contract/:address/smart/:query_data",
+            get(smart_contract_state),
+        )
+        .route(
+            "/v1/contract/:address/raw/:query_data",
+            get(raw_contract_state),
+        )
+}


### PR DESCRIPTION
## Summary
- add REST API for `x/wasm`
- update progress checklist

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets` *(fails: Unable to find libudev)*
- `cargo test --workspace` *(fails: Unable to find libudev)*

------
https://chatgpt.com/codex/tasks/task_e_684f3140457083219f455eb70b5c31b2