### PR TITLE
Implement wasm module root

### DIFF
--- a/COSMWASM_PROGRESS.md
+++ b/COSMWASM_PROGRESS.md
@@ -17,5 +17,5 @@ Below is the recommended order for implementing the files within `x/wasm`. Each 
 - [x] **x/wasm/src/client/cli/mod.rs** – groups the query and transaction CLI into a single module.
 - [x] **x/wasm/src/client/grpc.rs** – gRPC service definitions exposing query and transaction helpers for external tooling.
 - [x] **x/wasm/src/client/rest.rs** – REST handlers mirroring the gRPC interface for web applications.
-- [ ] **x/wasm/src/client/mod.rs** – aggregates CLI, gRPC and REST interfaces for consumers.
-- [ ] **x/wasm/src/lib.rs** – module root re-exporting the keeper, engine, clients and other components; depends on all previous files.
+- [x] **x/wasm/src/client/mod.rs** – aggregates CLI, gRPC and REST interfaces for consumers.
+- [x] **x/wasm/src/lib.rs** – module root re-exporting the keeper, engine, clients and other components; depends on all previous files.

--- a/x/wasm/src/client/mod.rs
+++ b/x/wasm/src/client/mod.rs
@@ -1,8 +1,22 @@
-//! Client-facing interfaces for the wasm module.
+//! Client-facing interfaces for the CosmWasm module.
 //!
-//! This directory defines CLI commands, REST handlers and gRPC services that
-//! expose wasm functionality to external users. The layout mirrors the
-//! structure used by other modules in this repository for consistency.
+//! This directory gathers the various ways an external application can
+//! interact with the module:
+//! - Command line utilities under [`cli`]
+//! - gRPC services under [`grpc`]
+//! - REST endpoints under [`rest`]
+//!
+//! The semantics of these interfaces are modelled after the original Go
+//! implementation in
+//! [`wasmd`](https://github.com/CosmWasm/wasmd/tree/main/x/wasm) and rely on
+//! the [`cosmwasm_vm`](https://github.com/CosmWasm/cosmwasm/tree/main/packages/vm)
+//! runtime. Behaviour mirrors the `wasmvm` bindings used in Go
+//! (<https://github.com/CosmWasm/wasmvm>) but is implemented natively in Rust.
+//! This crate exposes them separately so consumers can pick the pieces they
+//! require.
+pub use cli::*;
+pub use grpc::*;
+pub use rest::*;
 pub mod cli;
 pub mod grpc;
 pub mod rest;

--- a/x/wasm/src/lib.rs
+++ b/x/wasm/src/lib.rs
@@ -1,8 +1,11 @@
 //! CosmWasm module scaffolding.
 //!
-//! This crate integrates the CosmWasm virtual machine (`cosmwasm_vm`) with the
-//! Gears application framework. It mirrors the design of the Go `x/wasm` module
-//! in [`wasmd`](https://github.com/CosmWasm/wasmd) but leverages Rust directly.
+//! This crate integrates the CosmWasm virtual machine
+//! ([`cosmwasm_vm`](https://github.com/CosmWasm/cosmwasm/tree/main/packages/vm))
+//! with the Gears application framework. It mirrors the design of the Go
+//! `x/wasm` module in [`wasmd`](https://github.com/CosmWasm/wasmd) while staying
+//! entirely in Rust.  The public API is modelled after the Go bindings provided
+//! by [`wasmvm`](https://github.com/CosmWasm/wasmvm).
 //!
 //! The crate exposes a public `Keeper` responsible for managing contract code
 //! and instances. Execution is delegated to a pluggable [`WasmEngine`] trait,
@@ -33,6 +36,7 @@ mod params;
 mod types;
 
 pub use abci_handler::*;
+pub use client::*;
 pub use engine::*;
 pub use error::*;
 pub use genesis::*;


### PR DESCRIPTION
## Summary
- document and re-export wasm components
- mark progress checklist for lib

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets` *(fails: libudev not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f350370548321ae53ddab13cd9320